### PR TITLE
adding docs for config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 design
 node_modules
+.project

--- a/_includes/docs/use/toc.html
+++ b/_includes/docs/use/toc.html
@@ -4,4 +4,5 @@
   <li><a href="/docs/use/commandline/">Using the brjs CLI</a></li>
   <li><a href="/docs/use/writing_tests/">Writing Tests</a></li>
   <li><a href="/docs/use/running_tests/">Running Tests</a></li>
+  <li><a href="/docs/use/config/">Config Options</a></li>
 </ul>

--- a/_includes/docs/use/toc.html
+++ b/_includes/docs/use/toc.html
@@ -4,5 +4,5 @@
   <li><a href="/docs/use/commandline/">Using the brjs CLI</a></li>
   <li><a href="/docs/use/writing_tests/">Writing Tests</a></li>
   <li><a href="/docs/use/running_tests/">Running Tests</a></li>
-  <li><a href="/docs/use/config/">Config Options</a></li>
+  <li><a href="/docs/use/config/">Config Files</a></li>
 </ul>

--- a/docs/use/config.md
+++ b/docs/use/config.md
@@ -1,0 +1,52 @@
+---
+layout: docs
+title: BladeRunnerJS Configuration Files
+permalink: /docs/use/config/
+notice: none
+---
+
+### bladerunner.conf
+
+Configuration options for BladeRunner and the built in Jetty server. Located in the conf directory at the root of the BladeRunnerJS install.
+
+```
+jettyPort:              The port the built in Jetty server will bind to.
+                        Default: 7070.
+                        
+defaultInputEncoding:   The input encoding for files read by BRJS.
+                        Default: UTF-8
+	
+defaultOutputEncoding:  The output encoding for files produced by BRJS. 
+                        Default: UTF-8
+
+loginRealm:             The login realm the Jetty server will use. 
+                        Only needed if you configure a login realm.
+                        Default: BladeRunnerLoginRealm
+```
+
+### app.conf
+
+Configuration options specific to an individual app. Located in the root of each app.
+
+```
+appNamespace:   The root namespace for the app.
+                Default: appns
+
+locales:        The locales supported by this app, seperated by a comma. 
+                A locale consists of either two lowercase characters, or two lower case characters follow by an underscore and two uppercase characters. 
+                Default: en
+```
+
+### .js-style
+
+`.js-style` contains a single line that specifies the JavaScript coding style for a directory, 
+	for use by AssetPlugins to detirmine which type of SourceModule to create for each source file. 
+`js=style` files in parent directories apply to any sub-directories and styles in sub-directories will override those in parent directories.
+Styles can be overridden multiple times, for example if an app has the style 'style1', a bladeset can have the style 'style2', 
+	and a blade inside that bladeset could have the style 'style1'.
+
+If no `js-style` is found the default is `node.js`.  Possible values are `node.js` &amp; `namespaced-js`.
+
+```
+node.js
+```


### PR DESCRIPTION
adding a page at '/docs/use/config/' for docs on the various config files.
