### PR TITLE
Make the generated internal anchors less brittle by basing them on the h...

### DIFF
--- a/js/jquery.toc.js
+++ b/js/jquery.toc.js
@@ -21,7 +21,9 @@
         anchorId = anchorNameEl.attr( 'name' );
       }
       else {
-        anchorId = config.anchorPrefix + tocLevel + '-' + tocSection;
+        // TODO: replace this work-around with a proper solution once <https://github.com/dafi/tocmd-generator/issues/1> is fixed
+//        anchorId = config.anchorPrefix + tocLevel + '-' + tocSection;
+        anchorId = encodeURIComponent(config.anchorPrefix + el.text().toLowerCase().replace(/ /g, '-'));
         if( innerSection ) {
           anchorId += '-' + innerSection;
         }


### PR DESCRIPTION
...eading name rather than the headings' current position.
