### PR TITLE
fixed broken table of contents entry

### DIFF
--- a/docs/use/getting_started.md
+++ b/docs/use/getting_started.md
@@ -39,7 +39,7 @@ It'll be time well-spent.
 
 In order to run BRJS you'll need Java 7 or above installed. If you haven't already got it installed we recommend [installing the JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) as it ensures that `java` is accessible from the command line/terminal after installation. To deploy the built app you'll need any web server that can serve static files, for the purposes of this guide well be using [Apache Tomcat](http://tomcat.apache.org/) since it's easy to install and it's only requirement is a JVM which you'll already have in order to run BRJS.
 
-## Download & Install BRJS
+## Download and Install BRJS
 
 <strong><a href="https://github.com/BladeRunnerJS/brjs/releases/" class="brjs-latest-download">Download the latest BRJS release</a></strong> and unzip it somewhere. We'll now refer to that unzipped location as `BRJS_HOME`. The BRJS CLI executable is `BRJS_HOME/sdk/brjs`.
 


### PR DESCRIPTION
[This page](http://bladerunnerjs.org/docs/use/getting_started/) currently shows this:
![screen shot 2014-12-01 at 18 54 12](https://cloud.githubusercontent.com/assets/298742/5251210/891bb600-798b-11e4-8d4c-c2425f4fbdaa.png)
Which is gross. Eww.

The root cause is something to do with jquery.toc.js freaking out over the ampersand encoding. It also attempts to link to `#download-26-install-brjs` like a weirdo.

This pr doesnt fix the root cause, but it does fix the page.
